### PR TITLE
Update use-google-login.js

### DIFF
--- a/src/use-google-login.js
+++ b/src/use-google-login.js
@@ -14,7 +14,7 @@ const useGoogleLogin = ({
   discoveryDocs,
   onFailure,
   uxMode,
-  scope,
+  loginScope,
   accessType,
   responseType,
   jsSrc,
@@ -73,7 +73,7 @@ const useGoogleLogin = ({
         discoveryDocs,
         ux_mode: uxMode,
         redirect_uri: redirectUri,
-        scope,
+        scope: loginScope,
         access_type: accessType
       }
 

--- a/src/use-google-logout.js
+++ b/src/use-google-logout.js
@@ -12,7 +12,7 @@ const useGoogleLogout = ({
   discoveryDocs,
   uxMode,
   redirectUri,
-  scope,
+  logoutScope,
   accessType,
   onLogoutSuccess
 }) => {
@@ -38,7 +38,7 @@ const useGoogleLogout = ({
         discoveryDocs,
         ux_mode: uxMode,
         redirect_uri: redirectUri,
-        scope,
+        scope: logoutScope,
         access_type: accessType
       }
       window.gapi.load('auth2', () => {


### PR DESCRIPTION
scope needs to be sent properly when specified inside <GoogleLogin .../>. Getting 403 authorization error without this